### PR TITLE
Add adopted texts scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Dutch European Parliament Adopted Texts
+
+This scraper collects Dutch-language adopted texts from the European Parliament website. Starting from the first available Table of Contents page at:
+
+```
+https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21-TOC_NL.html
+```
+
+The scraper follows the "Volgende" links to navigate chronologically. For each page the `-TOC` part of the URL is removed to obtain the actual adopted text, for example:
+
+```
+https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21_NL.html
+```
+
+Scraped texts are uploaded to the Hugging Face dataset repository [`vGassen/Dutch-European-Parliament-Adopted-Texts`](https://huggingface.co/datasets/vGassen/Dutch-European-Parliament-Adopted-Texts).
+
+## Usage
+
+Run the scraper locally using Python 3:
+
+```bash
+pip install -r requirements.txt
+python scraper.py
+```
+
+Set the environment variables `HF_USERNAME` and `HF_TOKEN` if you wish to automatically push the data to Hugging Face Hub.

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,0 @@
-Source URL:
-https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21-TOC_NL.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+beautifulsoup4
+lxml
+datasets
+huggingface-hub
+tqdm

--- a/scraper.py
+++ b/scraper.py
@@ -4,24 +4,19 @@ from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
-from lxml import etree
 from datasets import Dataset
 from huggingface_hub import HfApi, login
 from tqdm import tqdm
 
-# Start from the first available minutes page and follow "Volgende" links
-START_TOC_URL = "https://www.europarl.europa.eu/doceo/document/PV-5-2003-05-12-TOC_NL.html"
+# Start from the first available adopted texts page and follow "Volgende" links
+START_TOC_URL = "https://www.europarl.europa.eu/doceo/document/TA-5-1999-07-21-TOC_NL.html"
 HF_USERNAME = os.environ.get("HF_USERNAME", "YOUR_HUGGINGFACE_USERNAME")
-HF_DATASET_NAME = "Dutch-European-Parliament-Minutes"
+HF_DATASET_NAME = "Dutch-European-Parliament-Adopted-Texts"
 HF_REPO_ID = f"{HF_USERNAME}/{HF_DATASET_NAME}"
 
-NAMESPACES = {
-    "text": "http://openoffice.org/2000/text",
-    "table": "http://openoffice.org/2000/table",
-}
 
 
-def collect_minutes_urls(start_url: str):
+def collect_text_urls(start_url: str):
     urls = []
     visited = set()
     current = start_url
@@ -32,8 +27,8 @@ def collect_minutes_urls(start_url: str):
         resp = session.get(current, timeout=20)
         resp.raise_for_status()
         soup = BeautifulSoup(resp.text, "lxml")
-        minutes_url = current.replace("-TOC_NL.html", "_NL.xml")
-        urls.append(minutes_url)
+        text_url = current.replace("-TOC", "")
+        urls.append(text_url)
         next_link = soup.find("a", title="Volgende")
         if not next_link:
             next_link = soup.find("a", string=re.compile("Volgende", re.I))
@@ -75,58 +70,8 @@ def clean_text(text: str) -> str:
     return text
 
 
-def extract_dutch_text_from_xml(xml_content: bytes) -> str | None:
-    """Parse XML minutes and return cleaned Dutch text."""
-    try:
-        parser = etree.XMLParser(recover=True, ns_clean=True)
-        root = etree.fromstring(xml_content, parser=parser)
-    except etree.XMLSyntaxError:
-        return None
-
-    dutch_texts = []
-    relevant_sections = [
-        "PV.Other.Text",
-        "PV.Debate.Text",
-        "PV.Vote.Text",
-        "PV.Sitting.Resumption.Text",
-        "PV.Approval.Text",
-        "PV.Agenda.Text",
-        "PV.Sitting.Closure.Text",
-    ]
-
-    for section in relevant_sections:
-        xpath_query = f"//{section}//text:p"
-        for p_tag in root.xpath(xpath_query, namespaces=NAMESPACES):
-            text_content = p_tag.xpath("string()").strip()
-            if not text_content:
-                continue
-            if p_tag.xpath("ancestor::table:table", namespaces=NAMESPACES):
-                continue
-            if (
-                p_tag.xpath("./Orator.List.Text", namespaces=NAMESPACES)
-                or p_tag.xpath("./Attendance.Participant.Name", namespaces=NAMESPACES)
-            ):
-                name_list_text = p_tag.xpath(
-                    "string(./Orator.List.Text)", namespaces=NAMESPACES
-                ).strip()
-                if (
-                    len(text_content) < 100
-                    and name_list_text
-                    and name_list_text == text_content
-                ):
-                    continue
-            if len(text_content) < 20 and not re.search(r"[a-zA-Z]{5,}", text_content):
-                continue
-            dutch_texts.append(text_content)
-
-    final_text = clean_text("\n".join(dutch_texts))
-    if final_text and len(final_text) > 50:
-        return final_text
-    return None
-
-
 def extract_dutch_text_from_html(html_content: str) -> str | None:
-    """Parse HTML minutes and return cleaned Dutch text."""
+    """Parse HTML adopted text and return cleaned Dutch text."""
     soup = BeautifulSoup(html_content, "lxml")
     paragraphs = [
         p.get_text(" ", strip=True) for p in soup.find_all("p") if p.get_text(strip=True)
@@ -137,27 +82,21 @@ def extract_dutch_text_from_html(html_content: str) -> str | None:
     return None
 
 
-def fetch_minutes_text(url: str, session: requests.Session) -> str | None:
+def fetch_text(url: str, session: requests.Session) -> str | None:
     resp = session.get(url, timeout=20)
-    if resp.status_code == 404 and url.endswith("_NL.xml"):
-        # Older minutes might only be available in HTML format
-        html_url = url.replace("_NL.xml", "_NL.html")
-        resp = session.get(html_url, timeout=20)
-        resp.raise_for_status()
-        return extract_dutch_text_from_html(resp.text)
     resp.raise_for_status()
-    return extract_dutch_text_from_xml(resp.content)
+    return extract_dutch_text_from_html(resp.text)
 
 
 def scrape() -> list:
-    toc_urls = collect_minutes_urls(START_TOC_URL)
+    toc_urls = collect_text_urls(START_TOC_URL)
     data = []
     with requests.Session() as session:
-        for url in tqdm(toc_urls, desc="Scraping minutes"):
+        for url in tqdm(toc_urls, desc="Scraping adopted texts"):
             try:
-                text = fetch_minutes_text(url, session)
+                text = fetch_text(url, session)
                 if text:
-                    data.append({"URL": url, "text": text, "source": "European Parliament Minutes"})
+                    data.append({"URL": url, "text": text, "source": "European Parliament Adopted Texts"})
             except Exception as e:
                 print(f"Failed to scrape {url}: {e}")
     return data


### PR DESCRIPTION
## Summary
- add MIT license and .gitignore
- document source and usage in README
- update workflow and scraper to pull adopted texts
- add Python requirements file

## Testing
- `python -m py_compile scraper.py`
- `python scraper.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856de848ef88329af1f3e7fa77fda56